### PR TITLE
Potential fix for code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/public/assets/vendor/php-email-form/validate.js
+++ b/public/assets/vendor/php-email-form/validate.js
@@ -76,9 +76,23 @@
     });
   }
 
+  function escapeHtml(str) {
+    if (typeof str !== "string") str = String(str);
+    return str.replace(/[&<>"']/g, function (m) {
+      switch (m) {
+        case '&': return '&amp;';
+        case '<': return '&lt;';
+        case '>': return '&gt;';
+        case '"': return '&quot;';
+        case "'": return '&#39;';
+        default: return m;
+      }
+    });
+  }
+
   function displayError(thisForm, error) {
     thisForm.querySelector('.loading').classList.remove('d-block');
-    thisForm.querySelector('.error-message').innerHTML = error;
+    thisForm.querySelector('.error-message').innerHTML = escapeHtml(error);
     thisForm.querySelector('.error-message').classList.add('d-block');
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ngaremaina/ngaremaina/security/code-scanning/1](https://github.com/Ngaremaina/ngaremaina/security/code-scanning/1)

To mitigate this XSS vulnerability, any data written to `.innerHTML` must be properly escaped to neutralize any HTML special characters, ensuring that user-controlled or tainted strings can't inject markup or scripts. Since only a string representation of the error is required for display, the safest approach is to encode the string before inserting it into the DOM. The change should occur in the `displayError` function in `public/assets/vendor/php-email-form/validate.js`, specifically where `.innerHTML` is set. A simple utility function (e.g., `escapeHtml`) can be defined to replace characters like `<`, `>`, `&`, `"`, and `'` with their respective HTML entities. This requires no additional libraries—plain JavaScript is sufficient.

You need to:
- Define an `escapeHtml` function in the same file.
- Use `escapeHtml(error)` in place of the raw `error` in `.innerHTML`.

No other code or functionality needs to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
