### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Ngaremaina/ngaremaina/security/code-scanning/2](https://github.com/Ngaremaina/ngaremaina/security/code-scanning/2)

The best way to fix the problem is to set an explicit `permissions:` block in the workflow, restricting GITHUB_TOKEN permissions to the least privilege necessary. In this workflow, all steps are related to source code checkout, installing dependencies, building, and testing, and do not require write access to repository contents or other scopes. Therefore, the minimal permission of `contents: read` suffices.

To implement, add the following at the workflow root, after the `name:` key and before `on:` (line 5). No imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
